### PR TITLE
Added `isort` to CI/CD checks

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -10,3 +10,6 @@ query-filters:
   # Reason: false positive on function body ellipsis (issue 11351)
   - exclude:
       id: py/ineffectual-statement
+  # Reason: no support for the TYPE_CHECKING directive (issue 4258)
+  - exclude:
+      id:  py/unsafe-cyclic-import

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ flake8:
 	flake8 streamflow_lsf tests
 
 format:
+	isort streamflow_lsf tests
 	black streamflow_lsf tests
 
 format-check:
+	isort --check-only streamflow_lsf tests
 	black --diff --check streamflow_lsf tests
 
 pyupgrade:

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black==24.10.0
 codespell==2.3.0
 flake8-bugbear==24.12.12
+isort==6.0.1
 pyupgrade==3.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ version = {attr = "streamflow_lsf.version.VERSION"}
 bandit = {file = "bandit-requirements.txt"}
 lint = {file = "lint-requirements.txt"}
 test = {file = "test-requirements.txt"}
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This commit adds the `isort` utility to sort `import` statements alphabetically.