### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   code-ql-check:
     name: "CodeQL check"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     steps:
@@ -24,7 +24,7 @@ jobs:
       - uses: github/codeql-action/analyze@v3
   static-checks:
     name: "Static checks"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         step: [ "bandit", "lint" ]
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   github:
     name: "Create GitHub Release"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -36,7 +36,7 @@ jobs:
           prerelease: false
   pypi:
     name: "Publish on PyPI"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment:
       name: pypi
       url: https://pypi.org/project/streamflow-lsf
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: "Get local version"
         run: echo "PLUGIN_VERSION=$(cat streamflow/plugins/unito/lsf/version.py | grep -oP '(?<=VERSION = \")(.*)(?=\")')" >> $GITHUB_ENV
       - name: "Get PyPI version"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ format-check:
 	black --diff --check streamflow tests
 
 pyupgrade:
-	pyupgrade --py3-only --py38-plus $(shell git ls-files | grep .py)
+	pyupgrade --py3-only --py39-plus $(shell git ls-files | grep .py)
 
 test:
 	python -m pytest -rs ${PYTEST_EXTRA}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "StreamFlow LSF plugin"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "LGPL-3.0-or-later"}
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -20,11 +20,11 @@ classifiers = [
     "Operating System :: MacOS",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing",
 ]

--- a/streamflow/plugins/unito/lsf/connector.py
+++ b/streamflow/plugins/unito/lsf/connector.py
@@ -7,7 +7,8 @@ import logging
 import os
 import re
 import shlex
-from typing import Any, MutableMapping, MutableSequence, cast
+from collections.abc import MutableMapping, MutableSequence
+from typing import Any, cast
 
 from importlib_resources import files
 from streamflow.core import utils

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   bandit
   lint
-  py3.{8,9,10,11,12}-unit
+  py3.{9,10,11,12,13}-unit
 skip_missing_interpreters = True
 
 [pytest]
@@ -12,16 +12,16 @@ testpaths = tests
 [testenv]
 allowlist_externals = make
 commands_pre =
-  py3.{8,9,10,11,12}-unit: python -m pip install -U pip setuptools wheel
+  py3.{9,10,11,12,13}-unit: python -m pip install -U pip setuptools wheel
 commands =
-  py3.{8,9,10,11,12}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
+  py3.{9,10,11,12,13}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
 deps =
-  py3.{8,9,10,11,12}-unit: -rrequirements.txt
-  py3.{8,9,10,11,12}-unit: -rtest-requirements.txt
+  py3.{9,10,11,12,13}-unit: -rrequirements.txt
+  py3.{9,10,11,12,13}-unit: -rtest-requirements.txt
 description =
-  py3.{8,9,10,11,12}-unit: Run the unit tests
+  py3.{9,10,11,12,13}-unit: Run the unit tests
 setenv =
-  py3.{8,9,10,11,12}-unit: LC_ALL = C.UTF-8
+  py3.{9,10,11,12,13}-unit: LC_ALL = C.UTF-8
 
 [testenv:bandit]
 commands = bandit -r streamflow


### PR DESCRIPTION
This commit introduces Python 3.9 features into the StreamFlow codebase, dropping support for Python 3.8. Moreover, it adds support for Python 3.13. Finally, it updates the Linux-based GitHub runner images  to the latest stable version (v24.04).
